### PR TITLE
fix: 修复上滑后立即return导致首个密码点击失败的问题

### DIFF
--- a/【小社脚本】启动程序.js
+++ b/【小社脚本】启动程序.js
@@ -2569,15 +2569,12 @@ function swipesUp(swipeCount, n) {
                 ), 1)) {
                 log(`上滑成功！`)
                 log(`需要密码解锁才能进桌面……`)
-                return;
-
             }
         } else {
             isLocked = KeyguardManager.isKeyguardLocked();
             if (!isLocked) {
                 log(`上滑成功！`);
                 log(`已经成功进入桌面……`)
-                return;
             }
         }
 


### PR DESCRIPTION
swipesUp方法在上滑后return，没有执行下面的休眠，导致解锁时第一个密码点击失败